### PR TITLE
Add account link to corporate bar

### DIFF
--- a/app/assets/stylesheets/corporate-bar.css.scss
+++ b/app/assets/stylesheets/corporate-bar.css.scss
@@ -13,6 +13,10 @@ $max-width: 960px !default; /* Neat's grid width setting */
   width: 100%;
   border-bottom: thin solid black;
   text-shadow: #777 0px -1px 0px;
+  i {
+    color: #DEDEDE;
+  }
+
   a {
     color: #DEDEDE;
     text-decoration: none;

--- a/app/helpers/radius_helper.rb
+++ b/app/helpers/radius_helper.rb
@@ -1,4 +1,12 @@
 module RadiusHelper
+  def kracken_url
+    if defined? Kracken
+      Kracken::PROVIDER_URL
+    else
+      ENV['RADIUS_OAUTH_PROVIDER_URL'].fetch { "https://account.radiusnetworks.com" }
+    end
+  end
+
   def environment_ribbon
     if ENV['ENVIRONMENT_NAME']
       content_tag(:div, ENV['ENVIRONMENT_NAME'], :id => 'environment_ribbon')

--- a/app/views/radius/_corporate_bar.html.erb
+++ b/app/views/radius/_corporate_bar.html.erb
@@ -16,7 +16,10 @@
       </li>
       <% if current_user %>
         <li>
-          <a href="http://account.radiusnetworks.com"> <i class="fa fa-user"></i> Account </a>
+        <a href="<%=kracken_url%>"> <i class="fa fa-user"></i> Account </a>
+        </li>
+        <li>
+        <a href="<%=kracken_url%>/teams"> <i class="fa fa-users"></i> Teams </a>
         </li>
         <li>
           <a href="<%=sign_out_path%>"> <i class="fa fa-sign-out"></i> Sign Out </a>

--- a/app/views/radius/_corporate_bar.html.erb
+++ b/app/views/radius/_corporate_bar.html.erb
@@ -14,17 +14,18 @@
           Shop
         </a>
       </li>
-      <li>
-          <% if current_user %>
-            <a href="<%=sign_out_path%>">
-              <i class="fa fa-sign-out"></i> Sign Out
-          </a>
-          <% else %>
-            <a href="<%=sign_in_path%>">
-              <i class="fa fa-sign-in"></i> Sign In
-            </a>
-          <% end %>
-      </li>
+      <% if current_user %>
+        <li>
+          <a href="http://account.radiusnetworks.com"> <i class="fa fa-user"></i> Account </a>
+        </li>
+        <li>
+          <a href="<%=sign_out_path%>"> <i class="fa fa-sign-out"></i> Sign Out </a>
+        </li>
+      <% else %>
+        <li>
+          <a href="<%=sign_in_path%>"> <i class="fa fa-sign-in"></i> Sign In </a>
+        </li>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/lib/radius/rails/version.rb
+++ b/lib/radius/rails/version.rb
@@ -1,5 +1,5 @@
 module Radius
   module Rails
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end


### PR DESCRIPTION
Currently there is no good way to go back and see account details or edit teams from the different apps. This add a very minimal "Account" link to the black bar. This way there is at least some path to finding your way back to Kracken so that passwords can be changed, teams can be edited, etc.

![image](https://cloud.githubusercontent.com/assets/16963/6255073/5365a812-b77b-11e4-9c05-b6a4356d3835.png)
