### PR TITLE
Remove require-tree

### DIFF
--- a/app/assets/javascripts/radius-theme.js
+++ b/app/assets/javascripts/radius-theme.js
@@ -11,5 +11,4 @@
 //= require flatdoc/flatdoc
 //= require slimScroll/jquery.slimscroll.min
 //= require screenfull/dist/screenfull
-//= require_tree ./radius-theme/
 


### PR DESCRIPTION
The `require_tree` loads _everything_ under the `js/radius-theme` directory, which is basically...
![everyone](https://cloud.githubusercontent.com/assets/12749147/19290940/372a1bf8-8fe0-11e6-96fb-0b8dae4e142a.gif)
The apps now specify the JS libraries that they specifically need, so this is not necessary.

