### PR TITLE
Add topnavbar to theme assets

### DIFF
--- a/app/helpers/radius_helper.rb
+++ b/app/helpers/radius_helper.rb
@@ -26,5 +26,23 @@ module RadiusHelper
     end
   end
 
+  def signout_user_path
+    if respond_to?(:destroy_user_session_path)
+      destroy_user_session_path
+    else
+      "#{kracken_url}/users/sign_out"
+    end
+  end
 
+  def manage_user_path
+    if respond_to?(:edit_user_registration_path)
+      edit_user_registration_path
+    else
+      "#{kracken_url}/users/edit"
+    end
+  end
+
+  def manage_teams_path
+    "#{kracken_url}/teams"
+  end
 end

--- a/app/views/radius/_topnavbar.html.erb
+++ b/app/views/radius/_topnavbar.html.erb
@@ -2,7 +2,7 @@
 <nav class="navbar topnavbar" role="navigation">
   <!--START navbar header-->
   <div class="navbar-header">
-    <a class="navbar-brand" href="//www.radiusnetworks.com/">
+    <a class="navbar-brand" href="https://www.radiusnetworks.com/">
       <div class="brand-logo">
         <img alt="App Logo" class="img-responsive" src="<%= image_path('radius-theme/logo.png') %>" />
       </div>
@@ -29,7 +29,7 @@
         </a>
       </li>
       <li>
-        <a href="//store.radiusnetworks.com" title="Radius Networks Store">
+        <a href="https://store.radiusnetworks.com" title="Radius Networks Store">
           <em class="icon-basket">
           </em>
         </a>
@@ -81,23 +81,24 @@
                 </div>
               </a>
               <!--list item-->
-              <a class="list-group-item" href="<%= manage_teams_path %>">
-                <div class="media-box">
-                  <div class="pull-left">
-                    <em class="fa fa-users fa-2x text-warning">
-                    </em>
+              <% if current_user.respond_to? :teams %>
+                <a class="list-group-item" href="<%= manage_teams_path %>">
+                  <div class="media-box">
+                    <div class="pull-left">
+                      <em class="fa fa-users fa-2x text-warning">
+                      </em>
+                    </div>
+                    <div class="media-box-body clearfix">
+                      <p class="m0">Teams</p>
+                      <p class="m0 text-muted">
+                      <small>
+                        You belong to <%= pluralize(current_user.teams.count ,"team") %>
+                      </small>
+                      </p>
+                    </div>
                   </div>
-                  <div class="media-box-body clearfix">
-                    <p class="m0">Teams</p>
-                    <p class="m0 text-muted">
-                    <small>
-                      You belong to <%= pluralize(current_user.accounts.count ,"team") %>
-                    </small>
-
-                    </p>
-                  </div>
-                </div>
-              </a>
+                </a>
+              <% end %>
             </div>
           </li>
         </ul>

--- a/app/views/radius/_topnavbar.html.erb
+++ b/app/views/radius/_topnavbar.html.erb
@@ -1,0 +1,111 @@
+<!--START Top Navbar-->
+<nav class="navbar topnavbar" role="navigation">
+  <!--START navbar header-->
+  <div class="navbar-header">
+    <a class="navbar-brand" href="//www.radiusnetworks.com/">
+      <div class="brand-logo">
+        <img alt="App Logo" class="img-responsive" src="<%= image_path('radius-theme/logo.png') %>" />
+      </div>
+      <div class="brand-logo-collapsed">
+        <img alt="App Logo" class="img-responsive" src="<%= image_path('radius-theme/logo-single.png') %>" />
+      </div>
+    </a>
+  </div>
+  <!--END navbar header-->
+  <!--START Nav wrapper-->
+  <div class="nav-wrapper">
+    <!--START Left navbar-->
+    <ul class="nav navbar-nav">
+      <li>
+        <!--Button used to collapse the left sidebar. Only visible on tablet and desktops-->
+        <a class="hidden-xs" data-toggle-state="aside-collapsed" href="#">
+          <em class="fa fa-navicon">
+          </em>
+        </a>
+        <!--Button to show/hide the sidebar on mobile. Visible on mobile only.-->
+        <a class="visible-xs sidebar-toggle" data-no-persist="true" data-toggle-state="aside-toggled" href="#">
+          <em class="fa fa-navicon">
+          </em>
+        </a>
+      </li>
+      <li>
+        <a href="//store.radiusnetworks.com" title="Radius Networks Store">
+          <em class="icon-basket">
+          </em>
+        </a>
+      </li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right">
+      <!--Search icon-->
+      <!--li-->
+      <!-- a data-search-open="" href="#"-->
+      <!--   em.icon-magnifier-->
+      <!--User Drop Down-->
+      <li class="dropdown dropdown-list">
+        <a data-toggle="dropdown" href="#">
+          <em class="icon-user">
+          </em>
+        </a>
+        <!--START Dropdown menu-->
+        <ul class="dropdown-menu animated flipInX">
+          <li>
+            <!--START list group-->
+            <div class="list-group">
+              <a class="list-group-item" href="<%= signout_user_path %>">
+                <div class="media-box">
+                  <div class="pull-left">
+                    <em class="fa fa-sign-out fa-2x text-info">
+                    </em>
+                  </div>
+                  <div class="media-box-body clearfix">
+                    <p class="m0">Sign Out</p>
+                    <p class="m0 text-muted">
+                    <small>Signed in as <%= current_user.email %></small>
+                    </p>
+                  </div>
+                </div>
+              </a>
+              <!--list item-->
+              <a class="list-group-item" href="<%= manage_user_path %>">
+                <div class="media-box">
+                  <div class="pull-left">
+                    <em class="fa fa-user fa-2x text-success">
+                    </em>
+                  </div>
+                  <div class="media-box-body clearfix">
+                    <p class="m0">User Account</p>
+                    <p class="m0 text-muted">
+                    <small>Edit Account Details</small>
+                    </p>
+                  </div>
+                </div>
+              </a>
+              <!--list item-->
+              <a class="list-group-item" href="<%= manage_teams_path %>">
+                <div class="media-box">
+                  <div class="pull-left">
+                    <em class="fa fa-users fa-2x text-warning">
+                    </em>
+                  </div>
+                  <div class="media-box-body clearfix">
+                    <p class="m0">Teams</p>
+                    <p class="m0 text-muted">
+                    <small>
+                      You belong to <%= pluralize(current_user.accounts.count ,"team") %>
+                    </small>
+
+                    </p>
+                  </div>
+                </div>
+              </a>
+            </div>
+          </li>
+        </ul>
+      </li>
+      <!--END Contacts menu-->
+    </ul>
+    <!--END Right Navbar-->
+  </div>
+  <!--END Nav wrapper-->
+</nav>
+<!--END Top Navbar-->


### PR DESCRIPTION
Converted the topnavbar to erb and added the partial.

This allow us to easily update the top navigation across any site that uses the radius theme and have it be consistent. The instigator here was removing the link to the plans page. Ya know, since there is no more plans page.

I added helpers for building the urls, most of them check to see if the equivalent route is defined and return that if so. These should only be defined in the Kracken Rails app itself, so the links in that dropdown will use the local app.

This works great for most links. The `destroy_user_session_path` is only defined in Kracken Rails, so can check if that exists; if it does use it, else build the url from the `kracken_url`. It doesn't work for `teams_path`, many of the client apps have a team controller so checking for that won't work well.

Finding a way to detect if we are in the Kracken Rails app proved to be tricky and out of the scope of this change. I am open to suggestions if you got 'em!

![image](https://user-images.githubusercontent.com/16963/40856160-d8d9bd64-65a4-11e8-8b9a-21012a22bcc9.png)
