### PR TITLE
Radius Custom Templates

### DIFF
--- a/app/assets/stylesheets/radius-theme/app/customizations.scss
+++ b/app/assets/stylesheets/radius-theme/app/customizations.scss
@@ -2,3 +2,20 @@
   float: none;
   margin: 0 auto;
 }
+
+.table-generic tr td a {
+  display: block;
+  text-decoration: none;
+  color: #656565;
+  &:hover {
+    color: #656565;
+    text-decoration: none;
+  }
+}
+
+.table.table-hover.table-generic {
+  th, td {
+    text-align: center;
+    vertical-align: middle;
+  }
+}

--- a/lib/radius-rails.rb
+++ b/lib/radius-rails.rb
@@ -1,9 +1,11 @@
 require "radius/rails"
 
-module RadiusRails
-  class Railtie < Rails::Railtie
-    config.app_generators do |g|
-      g.templates.unshift File::expand_path('../templates', __FILE__)
+module Radius
+  module Rails
+    class Railtie < ::Rails::Railtie
+      config.app_generators do |g|
+        g.templates.unshift File.expand_path('templates', __dir__)
+      end
     end
   end
 end

--- a/lib/radius-rails.rb
+++ b/lib/radius-rails.rb
@@ -1,1 +1,9 @@
 require "radius/rails"
+
+module RadiusRails
+  class Railtie < Rails::Railtie
+    config.app_generators do |g|
+      g.templates.unshift File::expand_path('../templates', __FILE__)
+    end
+  end
+end

--- a/lib/radius/rails/version.rb
+++ b/lib/radius/rails/version.rb
@@ -1,5 +1,5 @@
 module Radius
   module Rails
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end

--- a/lib/templates/rails/scaffold_controller/controller.rb.tt
+++ b/lib/templates/rails/scaffold_controller/controller.rb.tt
@@ -26,7 +26,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
 
     if @<%= orm_instance.save %>
-      redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully created.'" %>
+      redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully created.'" %>
     else
       render :new
     end
@@ -34,7 +34,7 @@ class <%= controller_class_name %>Controller < ApplicationController
 
   def update
     if @<%= orm_instance.update("#{singular_table_name}_params") %>
-      redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully updated.'" %>
+      redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully updated.'" %>
     else
       render :edit
     end

--- a/lib/templates/rails/scaffold_controller/controller.rb.tt
+++ b/lib/templates/rails/scaffold_controller/controller.rb.tt
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+<% if namespaced? -%>
+require_dependency "<%= namespaced_path %>/application_controller"
+
+<% end -%>
+<% module_namespacing do -%>
+class <%= controller_class_name %>Controller < ApplicationController
+  before_action :set_<%= singular_table_name %>, only: %i[show edit update destroy]
+
+  def index
+    @<%= plural_table_name %> = <%= singular_table_name.capitalize %>.accessible_by_user(current_user).all
+  end
+
+  def show
+  end
+
+  def new
+    @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
+  end
+
+  def edit
+  end
+
+  def create
+    @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
+
+    if @<%= orm_instance.save %>
+      redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully created.'" %>
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @<%= orm_instance.update("#{singular_table_name}_params") %>
+      redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully updated.'" %>
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @<%= orm_instance.destroy %>!
+    redirect_to <%= index_helper %>_url, notice: <%= "'#{human_name} was successfully destroyed.'" %>
+  end
+
+private
+
+  def set_<%= singular_table_name %>
+    @<%= singular_table_name %> = <%= singular_table_name.capitalize %>.accessible_by_user(current_user).find(params[:id])
+  end
+
+  def <%= "#{singular_table_name}_params" %>
+    <%- if attributes_names.empty? -%>
+    params.fetch(:<%= singular_table_name %>, {})
+    <%- else -%>
+    params.require(:<%= singular_table_name %>)
+          .permit(
+<% attributes_names.each do |name| -%>
+            :<%= name %>,
+<% end -%>
+          )
+    <%- end -%>
+  end
+end
+<% end -%>

--- a/lib/templates/slim/scaffold/_form.html.slim.tt
+++ b/lib/templates/slim/scaffold/_form.html.slim.tt
@@ -1,14 +1,10 @@
 = form_for @<%= singular_table_name %> do |f|
   .row
-    .col-lg-8
-      = render "layouts/partials/form_errors", resource: @<%= singular_table_name %>
-
-  .row
-    .col-lg-8
+    .col-sm-12.col-md-10.col-lg-8
       .panel.panel-default
-        .panel-heading
-          .panel-title <%= singular_table_name.titleize %> Details
+
         .panel-body
+          = render "layouts/partials/form_errors", resource: @<%= singular_table_name %>
 <% attributes.each do |attribute| -%>
           .form-group.has-feedback
 <% if attribute.password_digest? -%>
@@ -36,9 +32,6 @@
 <% end -%>
 <% end -%>
 
-  .row
-    .col-lg-8
-      .panel.panel-default
-        .panel-body
+        .panel-footer
           = f.submit class: "btn btn-sm pull-right btn-primary"
           = link_to 'Cancel', <%= index_helper %>_url, class: "btn btn-sm btn-default"

--- a/lib/templates/slim/scaffold/_form.html.slim.tt
+++ b/lib/templates/slim/scaffold/_form.html.slim.tt
@@ -1,0 +1,44 @@
+= form_for @<%= singular_table_name %> do |f|
+  .row
+    .col-lg-8
+      = render "layouts/partials/form_errors", resource: @<%= singular_table_name %>
+
+  .row
+    .col-lg-8
+      .panel.panel-default
+        .panel-heading
+          .panel-title <%= singular_table_name.titleize %> Details
+        .panel-body
+<% attributes.each do |attribute| -%>
+          .form-group.has-feedback
+<% if attribute.password_digest? -%>
+            = f.label :password
+            = f.password_field :password, class: "form-control"
+          .form-group.has-feedback
+            = f.label :password_confirmation
+            = f.password_field :password_confirmation, class: "form-control"
+<% else -%>
+            = f.label :<%= attribute.column_name %>
+<% case attribute.field_type -%>
+<% when :check_box -%>
+            .checkbox.c-checkbox.mt0
+              label
+                = f.check_box :<%= attribute.column_name %>, class: 'form-control'
+                span.fa.fa-check
+<% when :datetime_select -%>
+            .datepicker.input-group.date
+              = f.text_field :<%= attribute.column_name %>, class: 'form-control'
+              span.input-group-addon
+                span.fa.fa-calendar
+<% else -%>
+            = f.<%= attribute.field_type %> :<%= attribute.column_name %>, class: "form-control"
+<% end -%>
+<% end -%>
+<% end -%>
+
+  .row
+    .col-lg-8
+      .panel.panel-default
+        .panel-body
+          = f.submit class: "btn btn-sm pull-right btn-primary"
+          = link_to 'Cancel', <%= index_helper %>_url, class: "btn btn-sm btn-default"

--- a/lib/templates/slim/scaffold/edit.html.slim.tt
+++ b/lib/templates/slim/scaffold/edit.html.slim.tt
@@ -1,0 +1,10 @@
+.content-heading
+  | Edit <%= singular_table_name.titleize %>
+
+ol.breadcrumb
+  li
+    = link_to "<%= plural_table_name.titleize %>", <%= index_helper %>_url
+  li
+    = link_to "Back", @<%= singular_table_name %>
+
+= render partial: 'form'

--- a/lib/templates/slim/scaffold/index.html.slim.tt
+++ b/lib/templates/slim/scaffold/index.html.slim.tt
@@ -1,0 +1,27 @@
+.content-heading
+  .btn-toolbar.pull-right
+    | <%= plural_table_name.titleize %>
+  | <%= plural_table_name.titleize %>
+
+ol.breadcrumb
+  li = link_to '<%= plural_table_name.titleize %>', <%= index_helper %>_path
+
+.row
+  .col-sm-12
+    .panel.panel-default
+      .panel-heading
+        | My <%= plural_table_name.titleize %>
+
+      table.table.table-hover.table-generic
+        thead
+          tr
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+            th <%= attribute.human_name %>
+<% end -%>
+
+        tbody
+          - @<%= plural_table_name %>.each do |<%= singular_table_name %>|
+            tr
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+              td = <%= singular_table_name %>.<%= attribute.name %>
+<% end -%>

--- a/lib/templates/slim/scaffold/index.html.slim.tt
+++ b/lib/templates/slim/scaffold/index.html.slim.tt
@@ -1,27 +1,32 @@
 .content-heading
   .btn-toolbar.pull-right
-    | <%= plural_table_name.titleize %>
+    = link_to 'New <%= singular_table_name.titleize %>', new_<%= singular_table_name %>_path, class: 'btn btn-sm btn-success', title: "Create new <%= singular_table_name %>"
   | <%= plural_table_name.titleize %>
 
 ol.breadcrumb
   li = link_to '<%= plural_table_name.titleize %>', <%= index_helper %>_path
 
 .row
-  .col-sm-12
+  .col-lg-12
     .panel.panel-default
       .panel-heading
-        | My <%= plural_table_name.titleize %>
-
-      table.table.table-hover.table-generic
-        thead
-          tr
-<% attributes.reject(&:password_digest?).each do |attribute| -%>
-            th <%= attribute.human_name %>
-<% end -%>
-
-        tbody
-          - @<%= plural_table_name %>.each do |<%= singular_table_name %>|
+      .table-responsive
+        table.table.table-hover.table-generic
+          thead
             tr
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
-              td = <%= singular_table_name %>.<%= attribute.name %>
+              th <%= attribute.human_name %>
 <% end -%>
+              th
+              th
+              th
+
+          tbody
+            - @<%= plural_table_name %>.each do |<%= singular_table_name %>|
+              tr
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+                td = <%= singular_table_name %>.<%= attribute.name %>
+<% end -%>
+                td = link_to 'Show', <%= singular_table_name %>
+                td = link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>)
+                td = link_to 'Destroy', <%= singular_table_name %>, method: :delete, data: { confirm: 'Are you sure?' }

--- a/lib/templates/slim/scaffold/new.html.slim.tt
+++ b/lib/templates/slim/scaffold/new.html.slim.tt
@@ -1,0 +1,8 @@
+.content-heading
+  | New <%= singular_table_name.titleize %>
+
+ol.breadcrumb
+  li
+    = link_to "<%= plural_table_name.titleize %>", <%= index_helper %>_url
+
+= render partial: 'form'

--- a/lib/templates/slim/scaffold/show.html.slim.tt
+++ b/lib/templates/slim/scaffold/show.html.slim.tt
@@ -1,0 +1,11 @@
+p#notice = notice
+
+<% attributes.each do |attribute| -%>
+p
+  strong <%= attribute.human_name %>:
+  = @<%= singular_table_name %>.<%= attribute.name %>
+<% end -%>
+
+=> link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)
+'|
+=< link_to 'Back', <%= index_helper %>_path

--- a/lib/templates/slim/scaffold/show.html.slim.tt
+++ b/lib/templates/slim/scaffold/show.html.slim.tt
@@ -1,11 +1,18 @@
-p#notice = notice
+.content-heading
+  .btn-toolbar.pull-right
+    = link_to "Edit", edit_<%= singular_table_name %>_path(@<%= singular_table_name %>), class: 'btn btn-sm btn-info'
+  | <%= singular_table_name.titleize %>
 
+ol.breadcrumb
+  li
+    = link_to "<%= plural_table_name.titleize %>", <%= index_helper %>_url
+
+.row
+  .col-sm-12.col-md-10.col-lg-8
+    .panel.panel-default
+      .panel-body
 <% attributes.each do |attribute| -%>
-p
-  strong <%= attribute.human_name %>:
-  = @<%= singular_table_name %>.<%= attribute.name %>
+        p
+          strong <%= attribute.human_name %>:
+          = @<%= singular_table_name %>.<%= attribute.name %>
 <% end -%>
-
-=> link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)
-'|
-=< link_to 'Back', <%= index_helper %>_path


### PR DESCRIPTION
I jumped the gun a bit on this PR - still WIP

Now we can use our Radius custom templates for a scaffolded controller and action views.  A project using this will still need to have `slim-rails` in it's own `Gemfile` since we are not monkey-patching any generators.  However, because of that, we need to tweak and work around the generators behavior.

By default, rails will look for a template, and generate that first one it finds.  Since our custom templates are in a gem, rails will find a template (default) in the project and spit it out. We want to check `radius-rails` first for any templates before going back to the defaults.  Those changes are in `lib/radius-rails.rb`.  I found that answer [here](https://stackoverflow.com/questions/5666595/how-to-override-a-rails-generator-template-in-a-gem).

I remember I had an issue with a datetimepicker that wasn't resolved in an early version of `2.0.0` so I bumped the version. 