### PR TITLE
Add _form_errors partial

### DIFF
--- a/app/views/application/_form_errors.html.slim
+++ b/app/views/application/_form_errors.html.slim
@@ -1,0 +1,6 @@
+- if resource.errors.any?
+  .alert.alert-danger
+    h2 = "#{pluralize(resource.errors.count, "error")} prohibited this from being saved:"
+    ul
+      - resource.errors.full_messages.each do |message|
+        li = message

--- a/lib/templates/slim/scaffold/_form.html.slim.tt
+++ b/lib/templates/slim/scaffold/_form.html.slim.tt
@@ -4,7 +4,7 @@
       .panel.panel-default
 
         .panel-body
-          = render "layouts/partials/form_errors", resource: @<%= singular_table_name %>
+          = render "form_errors", resource: @<%= singular_table_name %>
 <% attributes.each do |attribute| -%>
           .form-group.has-feedback
 <% if attribute.password_digest? -%>


### PR DESCRIPTION
Not sure if there are other partials we should add, but I know this partial was giving us issues.

To render this partial:

```ruby
= render "form_errors", resource: @resource
```

The partial belongs in `application` folder, the issue I was having earlier was because I didn't run `puma-dev --stop` 😡 .

Once we do merge, we can bump `radius-rails` gem for all our projects and remove the partial.