### PR TITLE
Adjust scaffolded error positioning and panel fieldset padding

### DIFF
--- a/app/assets/stylesheets/radius-theme.scss
+++ b/app/assets/stylesheets/radius-theme.scss
@@ -2,6 +2,20 @@
 @import "radius-theme/masquerade";
 
 // Radius Theme Customizations / Extensions
+.panel-body {
+  fieldset {
+    &.last-child,
+    &:last-child {
+      padding-bottom: 0;
+    }
+  }
+}
+
 .panel-errors {
   padding: $panel-body-padding;
+
+  .alert {
+    margin-bottom: 0;
+    padding-bottom: $line-height-computed;
+  }
 }

--- a/app/assets/stylesheets/radius-theme.scss
+++ b/app/assets/stylesheets/radius-theme.scss
@@ -1,3 +1,7 @@
 @import "radius-theme/app";
 @import "radius-theme/masquerade";
 
+// Radius Theme Customizations / Extensions
+.panel-errors {
+  padding: $panel-body-padding;
+}

--- a/lib/templates/slim/scaffold/_form.html.slim.tt
+++ b/lib/templates/slim/scaffold/_form.html.slim.tt
@@ -2,9 +2,11 @@
   .row
     .col-sm-12.col-md-10.col-lg-8
       .panel.panel-default
+        - if @<%= singular_table_name %>.errors.any?
+          .panel-errors
+            = render "form_errors", resource: @<%= singular_table_name %>
 
         .panel-body
-          = render "form_errors", resource: @<%= singular_table_name %>
 <% attributes.each do |attribute| -%>
           .form-group.has-feedback
 <% if attribute.password_digest? -%>


### PR DESCRIPTION
## Errors Partial Within Form

This moves the partial from within the panel body to it's own errors section. This leaves the default panel body padding to keep it aligned with the other form elements.

This change is necessary because when a `.panel-heading` is present it appears above the errors:

**Before PR**

![image](https://user-images.githubusercontent.com/1524496/52147220-05dc7680-2634-11e9-9348-d2ac83f677dc.png)

**PR**

![image](https://user-images.githubusercontent.com/1524496/52147589-3375ef80-2635-11e9-8f9c-79ba13d340ff.png)

It also has nice spacing when a `.panel-heading` element is not present:

![image](https://user-images.githubusercontent.com/1524496/52147653-63bd8e00-2635-11e9-8550-262c492f1a91.png)

## Fieldset Padding


**Before PR**

![image](https://user-images.githubusercontent.com/1524496/52147800-d3cc1400-2635-11e9-92b6-af9f994b6e9e.png)


**PR**

![image](https://user-images.githubusercontent.com/1524496/52147824-e0e90300-2635-11e9-9ab3-91d55c404b46.png)

For comparison, here's a form with the final `.panel-body` element not being within a fieldset:

![image](https://user-images.githubusercontent.com/1524496/52147873-0b3ac080-2636-11e9-88df-2800f07127fe.png)
