### PR TITLE
Widens wd-xl class to accommodate potential recaptcha challenge

### DIFF
--- a/app/assets/stylesheets/radius-theme/app/utils-definitions.scss
+++ b/app/assets/stylesheets/radius-theme/app/utils-definitions.scss
@@ -1,5 +1,5 @@
-// 
-// Utilities classes to simplify 
+//
+// Utilities classes to simplify
 // components constructions
 // ------------------------------
 
@@ -28,7 +28,7 @@ $wd-sm:                 150px;
 $wd-sd:                 200px; // sd == standard
 $wd-md:                 240px;
 $wd-lg:                 280px;
-$wd-xl:                 320px;
+$wd-xl:                 335px;
 $wd-xxl:                360px;
 $wd-wide:               100%;
 $wd-auto:               auto;


### PR DESCRIPTION
The added recaptcha backup challenge (see https://github.com/RadiusNetworks/kracken/pull/500) is just a little bit too wide. 15 more pixels for this class gives it plenty of room and doesn't drastically change the look of the page.

<img width="348" alt="Screen Shot 2020-07-13 at 9 58 04 AM" src="https://user-images.githubusercontent.com/1019782/87313188-83760880-c4ef-11ea-9172-7c5bebc5812c.png">
