### PR TITLE
Replicate form_errors partial to common area

### DIFF
--- a/app/views/radius/forms/_form_errors.html.slim
+++ b/app/views/radius/forms/_form_errors.html.slim
@@ -1,0 +1,6 @@
+- if resource.errors.any?
+  .alert.alert-danger
+    h2 = "#{pluralize(resource.errors.count, "error")} prohibited this from being saved:"
+    ul
+      - resource.errors.full_messages.each do |message|
+        li = message

--- a/lib/radius/rails/version.rb
+++ b/lib/radius/rails/version.rb
@@ -1,5 +1,5 @@
 module Radius
   module Rails
-    VERSION = "2.1.2"
+    VERSION = "2.1.3"
   end
 end


### PR DESCRIPTION
Ref #23

To actually close this issue the original file needs to be removed, but
I don't want to do that until we've fixed the references in other apps.


This PR copies the file to the new location. I'm going to update https://github.com/RadiusNetworks/iris/pull/3344 to point to this new location instead to reduce churn on these files.

After that I'll vet out any other usages of `form_errors` and point them to the correct place, then we can remove the original file here.