### PR TITLE
Removes old form_errors partial

### DIFF
--- a/app/views/application/_form_errors.html.slim
+++ b/app/views/application/_form_errors.html.slim
@@ -1,6 +1,0 @@
-- if resource.errors.any?
-  .alert.alert-danger
-    h2 = "#{pluralize(resource.errors.count, "error")} prohibited this from being saved:"
-    ul
-      - resource.errors.full_messages.each do |message|
-        li = message

--- a/lib/radius/rails/version.rb
+++ b/lib/radius/rails/version.rb
@@ -1,5 +1,5 @@
 module Radius
   module Rails
-    VERSION = "2.1.3"
+    VERSION = "3.0.0"
   end
 end


### PR DESCRIPTION
Closes #23

This, I believe, requires a major version bump because it is removing
the backwards compatibility.

The only change here is the removal of this file, which was replicated at a different location (ref: #25). The apps that use the current version of this gem have been cleared for this change (see list below). They have *not* been updated to this version (3.x) but that can be done passively the next time we add stuff to it. 

Requires updates to be done in:

 - [x] iris - RadiusNetworks/iris#3344
 - [x] captain - RadiusNetworks/captain#1842
 - [x] kracken - RadiusNetworks/kracken#589
 - ~krite~