### PR TITLE
Use <= contraint on railties instead of pessimistic version lock

### DIFF
--- a/radius-rails.gemspec
+++ b/radius-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   #spec.add_dependency "font-awesome-rails"
-  spec.add_dependency "railties", ">= 3.2", "~> 6.0"
+  spec.add_dependency "railties", ">= 3.2", "<= 6.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 12.3.3"


### PR DESCRIPTION
This was causing us some issues when attempting to upgrade some gems
in iris. Using <= over ~> resolves this issue