### PR TITLE
Adds universal ValidatingEnum support for apps using this gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,39 @@ Add the `environment_ribbon` partial right after the opening body tag.
 body
   == render 'radius/environment_ribbon'
 ```
+
+
+### Validating Enum Types
+
+When using an `enum`, the default `enum` behavior is to disruptively raise an exception when the
+code tries to use a type that isn't within the set. Sometimes this is desired. Other times you want
+a gentler response: to render the model invalid, so that it can be remediated by the user through
+conventional paths.
+
+The `validating_enum` is a new type helper that can be used in ActiveRecord models to transparently
+accomplish this.
+
+Basic usage:
+```ruby
+class ThrownFruit < ApplicationRecord
+  validating_enum fruit_type: %w[apple banana cherry]
+end
+```
+adds this behavior:
+```ruby
+[1] pry(main)> f = ThrownFruit.last
+=>  #<ThrownFruit:0x00000001deadbeef # ...
+[2] pry(main)> f.fruit_type = :tomato
+=> :tomato
+[3] pry(main)> f.valid?
+=> false
+[4] pry(main)> f.errors
+=> #<ActiveModel::Errors:0x00000005cab
+ @base=
+  #<ThrownFruit:0x00000001deadbeef
+   #...>,
+ @details={:fruit_type=>[{:error=>:inclusion, :value=>:tomato}]},
+ @messages={:fruit_type=>["is not included in the list"]}>
+```
+
+Additional examples can be found in [app/models/concerns/validating_enum.rb](https://github.com/RadiusNetworks/radius-rails/blob/master/app/models/concerns/validating_enum.rb#L5-L34).

--- a/app/models/concerns/validating_enum.rb
+++ b/app/models/concerns/validating_enum.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Ref: https://medium.com/nerd-for-tech/using-activerecord-enum-in-rails-35edc2e9070f
+module ValidatingEnum
+  # Macro that wraps the standard Rails `enum` with additional type behavior to support
+  # intutive validation of enum selections
+  #
+  # Be sure to add `extend ValidatingEnum` to each model using this
+  #
+  # @param definitions [Hash{Symbol => Object}]
+  #   enum definition and configuration options
+  #
+  # @example Simple minimal example
+  #   validating_enum fruits: %w[apple banana orange]
+  #
+  #   # That is equivalent to writing
+  #   enum fruits: %w[apple banana orange]
+  #   validates :fruits, inclusion: { in: %w[apple banana orange] }
+  #
+  # @example Using standard enum options, such as _prefix
+  #   validating_enum fruits: %w[apple banana orange], _prefix: :available
+  #
+  # @example No default validation
+  #   validating_enum fruits: %w[apple banana orange], _validates: false
+  #
+  # @example Custom validation settings
+  #   validating_enum fruits: %w[apple banana orange],
+  #                   _validates: { allow_blank: true, message: "%{value} is prohibited" }
+  #
+  #   # That is equivalent to writing
+  #   enum sample: fruits: %w[apple banana orange]
+  #   validates :fruits, inclusion: {
+  #     in: %w[apple banana orange],
+  #     allow_blank: true,
+  #     message: "%{value} is prohibited",
+  #   }
+  # @see https://api.rubyonrails.org/v5.2.6/classes/ActiveRecord/Enum.html
+  def validating_enum(definitions) # rubocop:disable Metrics/MethodLength
+    # Extract the validation options as they are not part of the `enum` definitions.
+    #
+    # We are prefixing the options with underscore for parity with the `enum` options.
+    flag_or_options = definitions.delete(:_validates)
+    validates_options = case flag_or_options
+                        when false
+                          nil
+                        when true, nil
+                          {}
+                        else
+                          Hash(flag_or_options)
+                        end
+
+    # Calling `enum` here will strip out the various options (e.g. `_prefix`) from `definitions`
+    # leaving us with just the enum name and value mappings.
+    enum definitions
+
+    definitions.each do |name, _values|
+      # We are not going to use the values associated with the mappings as they may be simple
+      # arrays. Instead we lookup the defined values per the prior call to enum and utilize those.
+      enum_values = defined_enums.fetch(name.to_s)
+
+      # The prior `enum` call utilizes this `decorate_attribute_type` under the hood. According to
+      # the docs, calling `decorate_attribute_type` twice with the same `column_name` and
+      # `decoratore_type` overrides the previous decorator; instead of decorating the attribute
+      # twice.
+      #
+      # Ref https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/attribute_decorators.rb#L12-L23
+      decorate_attribute_type(name, 'enum') do |subtype|
+        ::ValidateableEnumType.new(name, enum_values, subtype)
+      end
+
+      if validates_options
+        validates name, inclusion: { in: enum_values.keys.map(&:to_s) }.merge(validates_options)
+      end
+    end
+  end
+end

--- a/app/models/concerns/validating_enum.rb
+++ b/app/models/concerns/validating_enum.rb
@@ -5,8 +5,6 @@ module ValidatingEnum
   # Macro that wraps the standard Rails `enum` with additional type behavior to support
   # intutive validation of enum selections
   #
-  # Be sure to add `extend ValidatingEnum` to each model using this
-  #
   # @param definitions [Hash{Symbol => Object}]
   #   enum definition and configuration options
   #

--- a/lib/radius-rails.rb
+++ b/lib/radius-rails.rb
@@ -1,10 +1,18 @@
 require "radius/rails"
 
+require_relative "types/validating_enum_type.rb"
+
 module Radius
   module Rails
     class Railtie < ::Rails::Railtie
       config.app_generators do |g|
         g.templates.unshift File.expand_path('templates', __dir__)
+      end
+
+      initializer 'validating_enum.initialize' do
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.send :extend, ValidatingEnum
+        end
       end
     end
   end

--- a/lib/radius-rails.rb
+++ b/lib/radius-rails.rb
@@ -11,7 +11,7 @@ module Radius
 
       initializer 'validating_enum.initialize' do
         ActiveSupport.on_load(:active_record) do
-          ActiveRecord::Base.send :extend, ValidatingEnum
+          ActiveRecord::Base.extend ValidatingEnum
         end
       end
     end

--- a/lib/radius/rails/version.rb
+++ b/lib/radius/rails/version.rb
@@ -1,5 +1,5 @@
 module Radius
   module Rails
-    VERSION = "3.0.0"
+    VERSION = "3.1.0"
   end
 end

--- a/lib/types/validating_enum_type.rb
+++ b/lib/types/validating_enum_type.rb
@@ -2,7 +2,9 @@
 
 # Ref: https://medium.com/nerd-for-tech/using-activerecord-enum-in-rails-35edc2e9070f
 class ValidateableEnumType < ActiveRecord::Enum::EnumType
-  # override the default behavior which normally bubbles an ArgumentError if the key is nonexistent
+  # This is called by the parent class when casting values from user provided input. The return
+  # value of this method is used as the return value from {#cast} when the value is not a defined
+  # enum. We return the user provided value so that the validator can catch issues later.
   #
   # @see https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/enum.rb#L138-L142
   def assert_valid_value(value)

--- a/lib/types/validating_enum_type.rb
+++ b/lib/types/validating_enum_type.rb
@@ -15,7 +15,7 @@ class ValidateableEnumType < ActiveRecord::Enum::EnumType
   #
   # @see https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/enum.rb#L134-L136
   def serialize(value)
-    return unless value
+    return if value.blank?
 
     case
     when mapping.key?(value)

--- a/lib/types/validating_enum_type.rb
+++ b/lib/types/validating_enum_type.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Ref: https://medium.com/nerd-for-tech/using-activerecord-enum-in-rails-35edc2e9070f
+class ValidateableEnumType < ActiveRecord::Enum::EnumType
+  # override the default behavior which normally bubbles an ArgumentError if the key is nonexistent
+  #
+  # @see https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/enum.rb#L138-L142
+  def assert_valid_value(value)
+    value
+  end
+
+  # Raise a KeyError if the value isn't a defined enum value during this conversion to a DB value
+  #
+  # @see https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/enum.rb#L134-L136
+  def serialize(value)
+    return unless value
+
+    case
+    when mapping.key?(value)
+      mapping[value]
+    when mapping.value?(value)
+      value
+    else
+      raise KeyError.new("unknown enum mapping: #{value.inspect}", key: value)
+    end
+  end
+end


### PR DESCRIPTION
Closes #32

This repackages and re-uses the ValidatingEnum code that we've tested out on our main app and authentication app. I wasn't completely sure on where to put certain files in a Gem context, so some of those decisions can probably be re-thought.

the `ValidatingEnum` module was put under app/models/concerns because that's where it was on both apps. It's just a plain module though that is extended by an AR model, so it could realistically be stored anywhere.

ValidatingEnumType is put under lib/types for the same reason -- that's where it was in the apps. This could also be stored anywhere. This file was required in the lib/radius-rails.rb file. I had looked up whether it would be preferable to load it through a RailTie, but since the original file wasn't specifically loaded through any AR config options, just a plain require, this seemed ok?

The one thing I'm unclear about and can definitely roll back if this is too aggressive, is the universal extension of the module. Currently, we have "extend ValidatingEnum" for classes that want to use it. I _did_ add a RailTie initializer here that will automatically extend it on every ActiveRecord model. Considering we're only currently using it on a handful of models, this might be unnecessary, though I do like that it makes it feel more like a generalized behavior that we're adding to the app. If the team preference is to allow this behavior only when opted-in, I'm happy to defer to that.

## Testing

I tested this by having the branch locally, and then modifying the `Gemfile` for an app that uses it (eg. `some_app`) to have this line:

```ruby
gem 'radius-rails', path: '/Users/amhill/code/radius-rails' # <-- use your username and path instead of mine :) 
```
instead of

```ruby
gem 'radius-rails', github: 'RadiusNetworks/radius-rails'
```

and then running `bundle install`

Once it's loaded, I tested it by removing the files currently added to `some_app` to support this feature, and re-running the tests. They failed and passed as expected.

 1. Remove `lib/types/validateable_enum_type.rb`
 2. Remove `app/models/concerns/validating_enum.rb`
 3. grep -lR validating_enum
 3. Run the specs that test those models