### PR TITLE
Comment out ValidatingEnum until we find a fix.

### DIFF
--- a/app/models/concerns/validating_enum.rb
+++ b/app/models/concerns/validating_enum.rb
@@ -1,74 +1,74 @@
-# frozen_string_literal: true
+# # frozen_string_literal: true
 
-# Ref: https://medium.com/nerd-for-tech/using-activerecord-enum-in-rails-35edc2e9070f
-module ValidatingEnum
-  # Macro that wraps the standard Rails `enum` with additional type behavior to support
-  # intutive validation of enum selections
-  #
-  # @param definitions [Hash{Symbol => Object}]
-  #   enum definition and configuration options
-  #
-  # @example Simple minimal example
-  #   validating_enum fruits: %w[apple banana orange]
-  #
-  #   # That is equivalent to writing
-  #   enum fruits: %w[apple banana orange]
-  #   validates :fruits, inclusion: { in: %w[apple banana orange] }
-  #
-  # @example Using standard enum options, such as _prefix
-  #   validating_enum fruits: %w[apple banana orange], _prefix: :available
-  #
-  # @example No default validation
-  #   validating_enum fruits: %w[apple banana orange], _validates: false
-  #
-  # @example Custom validation settings
-  #   validating_enum fruits: %w[apple banana orange],
-  #                   _validates: { allow_blank: true, message: "%{value} is prohibited" }
-  #
-  #   # That is equivalent to writing
-  #   enum sample: fruits: %w[apple banana orange]
-  #   validates :fruits, inclusion: {
-  #     in: %w[apple banana orange],
-  #     allow_blank: true,
-  #     message: "%{value} is prohibited",
-  #   }
-  # @see https://api.rubyonrails.org/v5.2.6/classes/ActiveRecord/Enum.html
-  def validating_enum(definitions) # rubocop:disable Metrics/MethodLength
-    # Extract the validation options as they are not part of the `enum` definitions.
-    #
-    # We are prefixing the options with underscore for parity with the `enum` options.
-    flag_or_options = definitions.delete(:_validates)
-    validates_options = case flag_or_options
-                        when false
-                          nil
-                        when true, nil
-                          {}
-                        else
-                          Hash(flag_or_options)
-                        end
+# # Ref: https://medium.com/nerd-for-tech/using-activerecord-enum-in-rails-35edc2e9070f
+# module ValidatingEnum
+#   # Macro that wraps the standard Rails `enum` with additional type behavior to support
+#   # intutive validation of enum selections
+#   #
+#   # @param definitions [Hash{Symbol => Object}]
+#   #   enum definition and configuration options
+#   #
+#   # @example Simple minimal example
+#   #   validating_enum fruits: %w[apple banana orange]
+#   #
+#   #   # That is equivalent to writing
+#   #   enum fruits: %w[apple banana orange]
+#   #   validates :fruits, inclusion: { in: %w[apple banana orange] }
+#   #
+#   # @example Using standard enum options, such as _prefix
+#   #   validating_enum fruits: %w[apple banana orange], _prefix: :available
+#   #
+#   # @example No default validation
+#   #   validating_enum fruits: %w[apple banana orange], _validates: false
+#   #
+#   # @example Custom validation settings
+#   #   validating_enum fruits: %w[apple banana orange],
+#   #                   _validates: { allow_blank: true, message: "%{value} is prohibited" }
+#   #
+#   #   # That is equivalent to writing
+#   #   enum sample: fruits: %w[apple banana orange]
+#   #   validates :fruits, inclusion: {
+#   #     in: %w[apple banana orange],
+#   #     allow_blank: true,
+#   #     message: "%{value} is prohibited",
+#   #   }
+#   # @see https://api.rubyonrails.org/v5.2.6/classes/ActiveRecord/Enum.html
+#   def validating_enum(definitions) # rubocop:disable Metrics/MethodLength
+#     # Extract the validation options as they are not part of the `enum` definitions.
+#     #
+#     # We are prefixing the options with underscore for parity with the `enum` options.
+#     flag_or_options = definitions.delete(:_validates)
+#     validates_options = case flag_or_options
+#                         when false
+#                           nil
+#                         when true, nil
+#                           {}
+#                         else
+#                           Hash(flag_or_options)
+#                         end
 
-    # Calling `enum` here will strip out the various options (e.g. `_prefix`) from `definitions`
-    # leaving us with just the enum name and value mappings.
-    enum definitions
+#     # Calling `enum` here will strip out the various options (e.g. `_prefix`) from `definitions`
+#     # leaving us with just the enum name and value mappings.
+#     enum definitions
 
-    definitions.each do |name, _values|
-      # We are not going to use the values associated with the mappings as they may be simple
-      # arrays. Instead we lookup the defined values per the prior call to enum and utilize those.
-      enum_values = defined_enums.fetch(name.to_s)
+#     definitions.each do |name, _values|
+#       # We are not going to use the values associated with the mappings as they may be simple
+#       # arrays. Instead we lookup the defined values per the prior call to enum and utilize those.
+#       enum_values = defined_enums.fetch(name.to_s)
 
-      # The prior `enum` call utilizes this `decorate_attribute_type` under the hood. According to
-      # the docs, calling `decorate_attribute_type` twice with the same `column_name` and
-      # `decoratore_type` overrides the previous decorator; instead of decorating the attribute
-      # twice.
-      #
-      # Ref https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/attribute_decorators.rb#L12-L23
-      decorate_attribute_type(name, 'enum') do |subtype|
-        ::ValidateableEnumType.new(name, enum_values, subtype)
-      end
+#       # The prior `enum` call utilizes this `decorate_attribute_type` under the hood. According to
+#       # the docs, calling `decorate_attribute_type` twice with the same `column_name` and
+#       # `decoratore_type` overrides the previous decorator; instead of decorating the attribute
+#       # twice.
+#       #
+#       # Ref https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/attribute_decorators.rb#L12-L23
+#       decorate_attribute_type(name, 'enum') do |subtype|
+#         ::ValidateableEnumType.new(name, enum_values, subtype)
+#       end
 
-      if validates_options
-        validates name, inclusion: { in: enum_values.keys.map(&:to_s) }.merge(validates_options)
-      end
-    end
-  end
-end
+#       if validates_options
+#         validates name, inclusion: { in: enum_values.keys.map(&:to_s) }.merge(validates_options)
+#       end
+#     end
+#   end
+# end

--- a/lib/radius-rails.rb
+++ b/lib/radius-rails.rb
@@ -1,6 +1,6 @@
 require "radius/rails"
 
-require_relative "types/validating_enum_type.rb"
+# require_relative "types/validating_enum_type.rb"
 
 module Radius
   module Rails
@@ -9,11 +9,11 @@ module Radius
         g.templates.unshift File.expand_path('templates', __dir__)
       end
 
-      initializer 'validating_enum.initialize' do
-        ActiveSupport.on_load(:active_record) do
-          ActiveRecord::Base.extend ValidatingEnum
-        end
-      end
+      # initializer 'validating_enum.initialize' do
+      #   ActiveSupport.on_load(:active_record) do
+      #     ActiveRecord::Base.extend ValidatingEnum
+      #   end
+      # end
     end
   end
 end

--- a/lib/radius/rails/version.rb
+++ b/lib/radius/rails/version.rb
@@ -1,5 +1,5 @@
 module Radius
   module Rails
-    VERSION = "3.1.0"
+    VERSION = "3.1.1"
   end
 end

--- a/lib/types/validating_enum_type.rb
+++ b/lib/types/validating_enum_type.rb
@@ -1,29 +1,29 @@
-# frozen_string_literal: true
+# # frozen_string_literal: true
 
-# Ref: https://medium.com/nerd-for-tech/using-activerecord-enum-in-rails-35edc2e9070f
-class ValidateableEnumType < ActiveRecord::Enum::EnumType
-  # This is called by the parent class when casting values from user provided input. The return
-  # value of this method is used as the return value from {#cast} when the value is not a defined
-  # enum. We return the user provided value so that the validator can catch issues later.
-  #
-  # @see https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/enum.rb#L138-L142
-  def assert_valid_value(value)
-    value
-  end
+# # Ref: https://medium.com/nerd-for-tech/using-activerecord-enum-in-rails-35edc2e9070f
+# class ValidateableEnumType < ActiveRecord::Enum::EnumType
+#   # This is called by the parent class when casting values from user provided input. The return
+#   # value of this method is used as the return value from {#cast} when the value is not a defined
+#   # enum. We return the user provided value so that the validator can catch issues later.
+#   #
+#   # @see https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/enum.rb#L138-L142
+#   def assert_valid_value(value)
+#     value
+#   end
 
-  # Raise a KeyError if the value isn't a defined enum value during this conversion to a DB value
-  #
-  # @see https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/enum.rb#L134-L136
-  def serialize(value)
-    return if value.blank?
+#   # Raise a KeyError if the value isn't a defined enum value during this conversion to a DB value
+#   #
+#   # @see https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/enum.rb#L134-L136
+#   def serialize(value)
+#     return if value.blank?
 
-    case
-    when mapping.key?(value)
-      mapping[value]
-    when mapping.value?(value)
-      value
-    else
-      raise KeyError.new("unknown enum mapping: #{value.inspect}", key: value)
-    end
-  end
-end
+#     case
+#     when mapping.key?(value)
+#       mapping[value]
+#     when mapping.value?(value)
+#       value
+#     else
+#       raise KeyError.new("unknown enum mapping: #{value.inspect}", key: value)
+#     end
+#   end
+# end


### PR DESCRIPTION
ValidatingEnum is broken in Rails 6. Commenting it out of the gem until we know it works. The code exists in Iris and Kracken as well. 