### PR TITLE
Silence deprecation warning with SASS color function 

### DIFF
--- a/app/assets/stylesheets/radius-theme/app/docs.scss
+++ b/app/assets/stylesheets/radius-theme/app/docs.scss
@@ -1,9 +1,12 @@
+@use "sass:color";
+
 // Margins
 $sidepad:   30px;  // Padding to the left of the sidebar
 
 // Colors
 $txt:       #505050;
 $accent:    $gray-dark;
+$hover-color: scale-color($accent, $lightness: -20%);
 
 // Dimensions
 $sidebar-width:   180px;
@@ -43,7 +46,7 @@ $pre-width:       380px;
         color: $accent;
       }
       &:hover {
-        color: $accent*0.8;
+        color: $hover-color;
         background-color: rgba(255,255,255,.75);
         text-decoration: none;
       }
@@ -75,12 +78,12 @@ $pre-width:       380px;
         color: $txt !important;
       }
       font-weight: bold !important;
-      
+
       // Indicator
       &:after {
         content: '';
         display: block;
-        
+
         position: absolute;
         top: 50%;
         margin-top: -2px;
@@ -101,7 +104,7 @@ $pre-width:       380px;
   @media only screen and (min-width: $mq-tablet) {
     margin: -20px; // expand over wrapper padding
   }
-  
+
   .flatdoc {
     @media only screen and (min-width: $mq-tablet) {
       display: table;
@@ -135,7 +138,7 @@ $pre-width:       380px;
       @include menubar();
     }
   }
-  
+
   .flatdoc-content {
     @media only screen and (min-width: $mq-tablet) {
       display: table-cell;
@@ -148,7 +151,7 @@ $pre-width:       380px;
     padding-top: 1px;
     padding-bottom: 50px;
     background-color: #fff;
-    
+
     pre {
       background-color: #f3f6fb;
       border: 1px solid $gray;
@@ -170,7 +173,7 @@ $pre-width:       380px;
         }
       }
     }
-    
+
     > h1 {
       padding: 11px 0;
       margin: 0;
@@ -183,7 +186,7 @@ $pre-width:       380px;
       margin: 0 -20px;
     }
   }
-  
+
   .button {
     display: inline-block;
     padding: 6px 16px;
@@ -194,4 +197,3 @@ $pre-width:       380px;
   }
 
 }
-

--- a/lib/radius/rails/version.rb
+++ b/lib/radius/rails/version.rb
@@ -1,5 +1,5 @@
 module Radius
   module Rails
-    VERSION = "3.1.1"
+    VERSION = "3.1.2"
   end
 end

--- a/radius-rails.gemspec
+++ b/radius-rails.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  #spec.add_dependency "font-awesome-rails"
   spec.add_dependency "railties", ">= 3.2", "<= 7.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Resolve a deprecation warning that we see often thanks to our use of the "times" operator:

```
The operation `#3a3f51 times 0.8` is deprecated and will be an error in future versions.
Consider using Sass's color functions instead.
https://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
```

This is done with the `scale-color` function that lightens the color by 20 percent.

Also, bump version to 3.1.2.

Resolves #20 
Resolves #26