### PR TITLE
Updates bundler version to 2.5.* 

### DIFF
--- a/lib/radius/rails/version.rb
+++ b/lib/radius/rails/version.rb
@@ -1,5 +1,5 @@
 module Radius
   module Rails
-    VERSION = "3.1.3"
+    VERSION = "3.1.4"
   end
 end

--- a/radius-rails.gemspec
+++ b/radius-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "railties", ">= 3.2", "< 8.0"
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.5"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "sass-rails"


### PR DESCRIPTION
which satisfies some deprecation warnings and should unblock release of gem.

Was previously `1.17.*` and is now `2.5.*` -- this is the version we use on `kracken` et al.