### PR TITLE
Remove upper bound for railties.

### DIFF
--- a/radius-rails.gemspec
+++ b/radius-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 3.2", "< 8.0"
+  spec.add_dependency "railties", ">= 3.2"
   spec.add_development_dependency "bundler", "~> 2.5"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "activesupport"


### PR DESCRIPTION
We want to try using this with Rails 8 app and it currently is limited to less than 8. We keep changing the upper limit when we have a new major version rails app, so we're going to remove it and figure out when it breaks.

