### PR TITLE
Add support for Rails 7+ (up to but not including 8)

### DIFF
--- a/lib/radius/rails/version.rb
+++ b/lib/radius/rails/version.rb
@@ -1,5 +1,5 @@
 module Radius
   module Rails
-    VERSION = "4.0.0"
+    VERSION = "4.0.1"
   end
 end

--- a/radius-rails.gemspec
+++ b/radius-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", "< 7.0"
+  spec.add_dependency "railties", "< 8.0"
   spec.add_development_dependency "bundler", "~> 2.5"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "activesupport"


### PR DESCRIPTION
This is necessary so that kracken (rails 7) can use Radius Rails 4.x